### PR TITLE
Automate open source contributions page + about page revisions

### DIFF
--- a/.github/workflows/update-contributions.yml
+++ b/.github/workflows/update-contributions.yml
@@ -1,0 +1,37 @@
+name: Update open source contributions
+
+on:
+  schedule:
+    - cron: "0 6 * * *"  # daily at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Regenerate contributions page
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 bin/update_open_source_contributions.py
+
+      - name: Commit changes if any
+        run: |
+          if git diff --quiet -- _projects/open_source_contributions.md; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add _projects/open_source_contributions.md
+          git commit -m "Update open source contributions [automated]"
+          git push

--- a/_projects/open_source_contributions.md
+++ b/_projects/open_source_contributions.md
@@ -1,27 +1,44 @@
 ---
 layout: page
 title: Open Source Contributions
-description: Active contributions to Apache Airflow, Delta Lake — focused on data infrastructure, observability, and provider tooling.
+description: Live snapshot of open, in-review, and merged pull requests to repositories outside my own projects.
 importance: 2
 category: side-projects
 ---
 
-I contribute to open-source projects in the data engineering and AI/ML infrastructure space. Contributions span provider tooling, observability improvements, and platform compatibility fixes.
+This page is generated automatically from GitHub pull request activity across @harishkesavarao, @harishkrao. It excludes personal repositories and personal forks, and only lists pull requests that are open, in review, or merged.
 
+#### Charcoal-SE/SmokeDetector
 
-#### Apache Airflow
-##### Databricks provider, Google provider, Snowflake provider
+- [hacktoberfest commit for issue-1432](https://github.com/Charcoal-SE/SmokeDetector/pull/2510) — merged
 
-[DatabricksPartitionSensor](https://github.com/apache/airflow/pull/30980) — authored and merged; enables partition-level sensing on Databricks tables for dependency management in Airflow DAGs
-[DatabricksSQLSensor](https://github.com/apache/airflow/pull/30477) — authored and merged; SQL-based sensing for Databricks workflows
-[Fix malformed URI](https://github.com/apache/airflow/pull/20509)† — Snowflake Connector
-Google BigQuery & PubSub provider [unit test fixes](https://github.com/apache/airflow/pull/22213)†
-Google Sheets & Simple HTTP [unit test fixes](https://github.com/apache/airflow/pull/22104)† 
+#### apache/airflow
 
-Note: contributions linked above marked with † were made under @harishkrao
+- [Bump datamodel-code-generator pin from 0.33.0 to 0.41.0](https://github.com/apache/airflow/pull/69854) — merged
+- [Add `DatabricksPartitionSensor`](https://github.com/apache/airflow/pull/30980) — merged
+- [Databricks SQL sensor](https://github.com/apache/airflow/pull/30477) — merged
+- [Issue 20453 google common cloud fixes part 1](https://github.com/apache/airflow/pull/22213) — merged
+- [Issue 20453 - Fixes the test_http and test_sheets assert calls only](https://github.com/apache/airflow/pull/22104) — merged
+- [Improvements for `SnowflakeHook.get_sqlalchemy_engine` ](https://github.com/apache/airflow/pull/20509) — merged
 
+#### apache/burr
 
-#### Delta Lake
-##### delta-io/delta
+- [Ecosystem page for Apache Burr](https://github.com/apache/burr/pull/661) — merged
+- [Update project references to Apache Burr and remove DAGWorks attributions](https://github.com/apache/burr/pull/659) — merged
 
-Improved error observability in SnapshotManager.getLogSegmentForVersion — enhanced diagnostics for version resolution failures, making debugging significantly faster for users hitting log segment errors ([PR](https://github.com/delta-io/delta/pull/5329) approved, pending merge)
+#### datahub-project/datahub
+
+- [Make Airflow plugin fully compatible with Airflow (WIP: partial changes)](https://github.com/datahub-project/datahub/pull/14482) — open, in review
+- [fix(airflow): set minimum supported version to 2.7.0 (#13357)](https://github.com/datahub-project/datahub/pull/13619) — merged
+
+#### delta-io/delta
+
+- [[kernel] Improve error messages in SnapshotManager.getLogSegmentFor…](https://github.com/delta-io/delta/pull/5329) — open, in review
+
+#### firstcontributions/first-contributions
+
+- [Add Harish Kesava Rao to Contributors list](https://github.com/firstcontributions/first-contributions/pull/11508) — merged
+
+#### realpython/python-guide
+
+- [issue-938: added sections in serialization for simple file, csv, yaml and json](https://github.com/realpython/python-guide/pull/947) — merged

--- a/bin/update_open_source_contributions.py
+++ b/bin/update_open_source_contributions.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Regenerate _projects/open_source_contributions.md from live GitHub PR data.
+
+Queries the GitHub GraphQL API for pull requests authored by the configured
+accounts, drops PRs against the accounts' own repos/forks (personal work),
+and writes out an auto-generated summary grouped by repository.
+"""
+import os
+import sys
+import urllib.request
+import json
+
+USERS = ["harishkesavarao", "harishkrao"]
+OWN_ACCOUNTS = {u.lower() for u in USERS}
+OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "..", "_projects", "open_source_contributions.md")
+
+GRAPHQL_URL = "https://api.github.com/graphql"
+
+QUERY = """
+query($searchQuery: String!, $after: String) {
+  search(query: $searchQuery, type: ISSUE, first: 100, after: $after) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      ... on PullRequest {
+        title
+        url
+        state
+        reviewDecision
+        createdAt
+        repository {
+          nameWithOwner
+          isFork
+          owner { login }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def graphql_request(query, variables, token):
+    body = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+    req = urllib.request.Request(
+        GRAPHQL_URL,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "User-Agent": "open-source-contributions-updater",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def fetch_prs(user, token):
+    prs = []
+    after = None
+    search_query = f"type:pr author:{user}"
+    while True:
+        data = graphql_request(QUERY, {"searchQuery": search_query, "after": after}, token)
+        if "errors" in data:
+            raise RuntimeError(data["errors"])
+        result = data["data"]["search"]
+        prs.extend(n for n in result["nodes"] if n)
+        if result["pageInfo"]["hasNextPage"]:
+            after = result["pageInfo"]["endCursor"]
+        else:
+            break
+    return prs
+
+
+def status_label(pr):
+    if pr["state"] == "MERGED":
+        return "merged"
+    if pr["state"] == "OPEN":
+        decision = pr.get("reviewDecision")
+        if decision == "APPROVED":
+            return "open, approved — pending merge"
+        if decision == "REVIEW_REQUIRED":
+            return "open, in review"
+        if decision == "CHANGES_REQUESTED":
+            return "open, changes requested"
+        return "open"
+    return None  # CLOSED (unmerged) - excluded
+
+
+def build_markdown(grouped):
+    lines = [
+        "---",
+        "layout: page",
+        "title: Open Source Contributions",
+        "description: Live snapshot of open, in-review, and merged pull requests to repositories outside my own projects.",
+        "importance: 2",
+        "category: side-projects",
+        "---",
+        "",
+        "This page is generated automatically from GitHub pull request activity across "
+        + ", ".join(f"@{u}" for u in USERS)
+        + ". It excludes personal repositories and personal forks, and only lists pull "
+        "requests that are open, in review, or merged.",
+        "",
+    ]
+    for repo in sorted(grouped):
+        lines.append(f"#### {repo}")
+        lines.append("")
+        for pr in sorted(grouped[repo], key=lambda p: p["createdAt"], reverse=True):
+            lines.append(f"- [{pr['title']}]({pr['url']}) — {status_label(pr)}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main():
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN environment variable is required", file=sys.stderr)
+        sys.exit(1)
+
+    grouped = {}
+    for user in USERS:
+        for pr in fetch_prs(user, token):
+            repo = pr["repository"]
+            owner = repo["owner"]["login"].lower()
+            if owner in OWN_ACCOUNTS:
+                continue  # personal repo or personal fork
+            label = status_label(pr)
+            if label is None:
+                continue  # closed, unmerged
+            grouped.setdefault(repo["nameWithOwner"], []).append(pr)
+
+    markdown = build_markdown(grouped)
+    with open(OUTPUT_PATH, "w") as f:
+        f.write(markdown)
+    print(f"Wrote {sum(len(v) for v in grouped.values())} PR(s) across {len(grouped)} repo(s) to {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a script + scheduled GitHub Action that regenerates `_projects/open_source_contributions.md` from live GitHub PR data (open, in review, or merged), excluding personal repos/forks
- Includes prior about-page revisions from this branch

## Test plan
- [x] Ran `bin/update_open_source_contributions.py` locally, confirmed correct filtering and grouping
- [ ] Verify scheduled workflow run succeeds in Actions tab after merge